### PR TITLE
Make `dirty` parameter consistent with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ The returned camera contains the following _computed_ properties which will be o
 
 | Camera variable | Type | Meaning |
 | -------------- | ---- | ------- |
-| `dirty` | Boolean | `true` | true when camera view has changed |
 | `eye` | vec3 | location of camera |
 | `projection` | mat4 | projection matrix |
 | `view` | mat4 | view matrix |
@@ -87,6 +86,7 @@ The returned camera contains a `.state` property which contains the following st
 | -------------- | ---- | ------- | ------- |
 | `aspectRatio` | Number | current aspect ratio |
 | `center` | vec3 | `[0, 0, 0]` | point at the center of the view |
+| `dirty` | Boolean | `true` | true when camera view has changed |
 | `distance` | Number | `10` |  distance of eye from center |
 | `dPhi` | Number | `0` | current phi inertia of camera |
 | `dTheta` | Number | `0` | current theta inertia of camera |

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ module.exports = function Camera (opts) {
     zoomDecayTime: opts.zoomDecayTime || 100,
     rotationDecayTime: opts.rotationDecayTime || 100,
 
+    dirty: true,
+
     up: opts.up || new Float32Array([0, 1, 0]),
     center: opts.center || new Float32Array(3),
     rotationCenter: opts.rotationCenter || opts.center && opts.center.slice() || new Float32Array(3),

--- a/index.js
+++ b/index.js
@@ -53,8 +53,8 @@ module.exports = function Camera (opts) {
     panX: 0,
     panY: 0,
     panZ: 0,
-		pitch: 0,
-		yaw: 0,
+    pitch: 0,
+    yaw: 0,
     dTheta: 0,
     dPhi: 0,
 


### PR DESCRIPTION
Thanks for the great package!

I was trying to use it and realized that the docs were somewhat inconsistent: at times the `dirty` param is referred to as `camera.state.dirty`, and at other times it's `camera.dirty`. The actual behavior is that it's set on the state, but it didn't have a default value (which was confusing me for a bit). I also made a minor style change, hope that's okay to go with this PR.