### PR TITLE
Remove `const`

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function createCamera (opts) {
   };
 
   var t0 = null;
-  const camera = {
+  var camera = {
     tick: function (mergeState) {
       // If we've accumulated interactions, then set them in the params directly.
       // Alternatively, we could recompute the full params on every single interaction


### PR DESCRIPTION
As a result of testing on an old iPad mini, I found a stray `const` that broke the bundle. This PR removes it. Publishing under `v2.0.4`.